### PR TITLE
Add metadata to enable source build (sdist) and debian packaging (stdeb)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ TAGS
 *egg-info
 build/
 docstring_pickle.pkl
+MANIFEST
+deb_dist
+dist

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include get_docstring.py README.txt stdeb.cfg
+include *.h *.c
+

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,0 +1,5 @@
+[DEFAULT]
+
+Build-Depends: python-numpy, gfortran. python-dev
+Depends: python-numpy
+#Debian-Version: atnf1


### PR DESCRIPTION
I have added a MANIFEST.in to enable the sdist command and a config file to create debian packages wwith stdeb. You could also add this to pypi now.
